### PR TITLE
feat(bss): zeroise the bss section on program entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,15 +71,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-dependencies = [
- "spin 0.5.2",
-]
-
-[[package]]
 name = "llvm-tools"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/bios/f-init/src/main.rs
+++ b/src/bios/f-init/src/main.rs
@@ -17,6 +17,7 @@ pub extern "C" fn _start() -> ! {
 }
 
 pub fn loader() -> ! {
+    flib::mem::zero_bss();
     rinfo!("loading second stage (mem: 0x07C00)");
     rinfo!("enabling A20 line");
     enable_a20();

--- a/src/bios/f-init32/f-init32.ld
+++ b/src/bios/f-init32/f-init32.ld
@@ -20,11 +20,11 @@ SECTIONS {
         *(.data .data.*)
     }
 
+    _bss_start = .;
     .bss : {
-        _bss_start = .;
         *(.bss .bss.*)
-        _bss_end = .;
     }
+    _bss_end = .;
 
     .eh_frame : {
         *(.eh_frame .eh_frame.*)

--- a/src/bios/f-init32/src/main.rs
+++ b/src/bios/f-init32/src/main.rs
@@ -33,6 +33,7 @@ pub extern "C" fn _start() -> ! {
 }
 
 pub fn boot_main() -> ! {
+    flib::mem::zero_bss();
     init_framebuffer();
     loop {}
 }

--- a/src/bios/flib/src/mem/mod.rs
+++ b/src/bios/flib/src/mem/mod.rs
@@ -1,2 +1,26 @@
+//! Memory related utilities module.
+
+use core::ptr;
+
 pub mod bmalloc;
 pub mod e820;
+
+/// Zeroise the .bss segment when entering the program.
+///
+/// Uses two external symbols `_bss_start` and `_bss_end` that must
+/// be added at link time and that points to the start and the end
+/// of the .bss section respectively.
+pub fn zero_bss() {
+    extern "C" {
+        static _bss_start: u8;
+        static _bss_end: u8;
+    }
+
+    unsafe {
+        let bss_start = &_bss_start as *const u8 as u32;
+        let bss_end = &_bss_end as *const u8 as u32;
+        let bss_len = bss_end - bss_start;
+
+        ptr::write_bytes(bss_start as *mut u8, 0, bss_len as usize);
+    }
+}


### PR DESCRIPTION
Zeroise the bss section on second and third stage entry.

The OS usually takes care of that for us, so the bootloader has to do it itself before any code gets executed.
It uses two external symbols `_bss_start` and `_bss_end` that must be manually added at link time.