### PR TITLE
feat(errors): improve global error handling

### DIFF
--- a/src/fzboot/err.rs
+++ b/src/fzboot/err.rs
@@ -1,0 +1,89 @@
+use core::fmt::Debug;
+
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+
+/// `BaseError` is a common trait implemented by every error type defined in FrozenBoot.
+///
+/// It is dependent on the [`Debug`] trait, which makes sense as we are dealing with errors.
+/// [`GenericError`] and general `Exception` are defined using this trait when paired with a global
+/// allocator (required for trait objects).
+pub trait BaseError: Debug {}
+
+/// `CanFail` is a return type for functions that are allowed to fail, and don't need to return
+/// anything.
+///
+/// For instance, it could be used when checking if a functionnality / feature is available on the
+/// system, or when initializing a component, or a shared `static`.
+///
+/// # Examples:
+///
+/// ```
+/// use fzboot::CanFail;
+///
+/// struct InitError {
+///     error: String
+/// }
+///
+/// fn init_component() -> CanFail<InitError> {
+///     todo!()
+/// }
+/// ```
+pub type CanFail<T> = Result<(), T>;
+
+/// `GenericError` is a return type for functions that do not raise specific / usual known errors.
+#[cfg(feature = "alloc")]
+pub type GenericError = Result<(), Box<dyn BaseError>>;
+
+#[cfg(not(feature = "alloc"))]
+pub type GenericError = Result<(), ()>;
+
+/// `VideoError` defines several error types useful when dealing with video / graphics related
+/// code.
+#[derive(Debug)]
+pub enum VideoError {
+    /// Generic VESA (usually VBE) related error.
+    VesaError,
+
+    #[cfg(feature = "alloc")]
+    /// Generic error.
+    Exception(Box<dyn BaseError>),
+
+    #[cfg(not(feature = "alloc"))]
+    /// Generic error.
+    Exception,
+}
+
+/// `IOError` defines several error types useful when communicating with input/output devices or
+/// components.
+pub enum IOError {
+    /// Operation resulted in a timeout.
+    IOTimeout,
+
+    #[cfg(feature = "alloc")]
+    /// Generic error.
+    Exception(Box<dyn BaseError>),
+
+    #[cfg(not(feature = "alloc"))]
+    /// Generic error.
+    Exception,
+}
+
+/// `ClockError` defines several error types useful when dealing with clock related components
+/// (such as HPET, TSC or RTC).
+pub enum ClockError {
+    /// The clock is not present / available on the system, or an error was raised when checking
+    /// for its availability.
+    NotPresent,
+
+    /// Error while trying to calibrate a clock.
+    CalibrationError,
+
+    #[cfg(feature = "alloc")]
+    /// Generic error.
+    Exception(Box<dyn BaseError>),
+
+    #[cfg(not(feature = "alloc"))]
+    /// Generic error.
+    Exception,
+}

--- a/src/fzboot/mod.rs
+++ b/src/fzboot/mod.rs
@@ -1,3 +1,8 @@
+mod err;
 #[cfg(feature = "alloc")]
 pub mod irq;
 pub mod time;
+
+pub mod errors {
+    pub use crate::fzboot::err::*;
+}

--- a/src/fzboot/real/src/pswitch/a20.rs
+++ b/src/fzboot/real/src/pswitch/a20.rs
@@ -1,13 +1,19 @@
 use core::arch::asm;
-use fzboot::io::{inb, outb};
-use fzboot::x86::int::{disable_interrupts, enable_interrupts};
+use fzboot::{
+    errors::GenericError,
+    x86::int::{disable_interrupts, enable_interrupts},
+};
+use fzboot::{
+    errors::{CanFail, IOError},
+    io::{inb, outb},
+};
 
 use fzboot::io::io_delay;
 use fzboot::io::ps2::{input_wait, output_wait, read_ps2, send_data, send_ps2};
 
 const A20_KTEST_LOOPS: u16 = 32;
 
-pub fn enable_a20() -> Result<(), ()> {
+pub fn enable_a20() -> GenericError {
     if __fast_a20_check() {
         return Ok(());
     }
@@ -15,9 +21,10 @@ pub fn enable_a20() -> Result<(), ()> {
     __bios_enable_a20()
         .or_else(|_| __kb_enable_a20())
         .or_else(|_| __fastg_enable_a20())
+        .map_err(|_| ())
 }
 
-fn __fastg_enable_a20() -> Result<(), ()> {
+fn __fastg_enable_a20() -> GenericError {
     let mut sysctrl_prt_a = inb(0x92);
     outb(0x92, sysctrl_prt_a | 2);
 
@@ -28,34 +35,35 @@ fn __fastg_enable_a20() -> Result<(), ()> {
     Err(())
 }
 
-fn __kb_enable_a20() -> Result<(), ()> {
+fn __kb_enable_a20() -> CanFail<IOError> {
     disable_interrupts();
 
-    input_wait(A20_KTEST_LOOPS);
+    input_wait(A20_KTEST_LOOPS)?;
     send_ps2(0xAD);
 
-    input_wait(A20_KTEST_LOOPS);
+    input_wait(A20_KTEST_LOOPS)?;
     send_ps2(0xD0);
 
-    output_wait(A20_KTEST_LOOPS);
+    output_wait(A20_KTEST_LOOPS)?;
     let ctrl_output: u8 = read_ps2();
 
-    input_wait(A20_KTEST_LOOPS);
+    input_wait(A20_KTEST_LOOPS)?;
     send_ps2(0xD1);
 
-    input_wait(A20_KTEST_LOOPS);
+    input_wait(A20_KTEST_LOOPS)?;
     send_data(ctrl_output | 2);
 
-    input_wait(A20_KTEST_LOOPS);
+    input_wait(A20_KTEST_LOOPS)?;
     send_ps2(0xAE);
 
     if __a20_check(A20_KTEST_LOOPS) {
         return Ok(());
     }
-    Err(())
+
+    Err(IOError::IOTimeout)
 }
 
-fn __bios_enable_a20() -> Result<(), ()> {
+fn __bios_enable_a20() -> GenericError {
     unsafe {
         asm!("mov ax, 0x2401", "int 0x15");
     }
@@ -67,7 +75,7 @@ fn __bios_enable_a20() -> Result<(), ()> {
 }
 
 fn __a20_check(mut loops: u16) -> bool {
-    while (loops > 0) {
+    while loops > 0 {
         if __fast_a20_check() {
             return true;
         };

--- a/src/io/ps2/mod.rs
+++ b/src/io/ps2/mod.rs
@@ -1,5 +1,7 @@
 use core::arch::asm;
 
+use crate::errors::{CanFail, IOError};
+
 pub fn send_data(data: u8) {
     unsafe {
         asm!(
@@ -31,7 +33,7 @@ pub fn send_ps2(cmd: u8) {
     }
 }
 
-pub fn input_wait(mut loops: u16) -> Result<(), ()> {
+pub fn input_wait(mut loops: u16) -> CanFail<IOError> {
     while loops > 0 {
         let status_reg: u8;
 
@@ -49,10 +51,10 @@ pub fn input_wait(mut loops: u16) -> Result<(), ()> {
         loops -= 1;
     }
 
-    Err(())
+    Err(IOError::IOTimeout)
 }
 
-pub fn output_wait(mut loops: u16) -> Result<(), ()> {
+pub fn output_wait(mut loops: u16) -> CanFail<IOError> {
     while loops > 0 {
         let status_reg: u8;
 
@@ -70,5 +72,5 @@ pub fn output_wait(mut loops: u16) -> Result<(), ()> {
         loops -= 1;
     }
 
-    Err(())
+    Err(IOError::IOTimeout)
 }

--- a/src/mem/e820.rs
+++ b/src/mem/e820.rs
@@ -136,7 +136,7 @@ fn e820_type_print(descriptor: &AddressRangeDescriptor) {
 }
 
 #[cfg(feature = "real")]
-pub fn memory_map() -> Result<(), ()> {
+pub fn memory_map() {
     use crate::rinfo;
 
     let mut entry_count: u16 = 0;
@@ -161,6 +161,4 @@ pub fn memory_map() -> Result<(), ()> {
     }
 
     unsafe { E820_MAP_LENGTH = entry_count };
-
-    Ok(())
 }

--- a/src/video/vesa/video_mode.rs
+++ b/src/video/vesa/video_mode.rs
@@ -4,7 +4,10 @@ use core::{arch::asm, ptr};
 
 use core::mem;
 
-use crate::vbe_const;
+use crate::{
+    errors::{CanFail, VideoError},
+    vbe_const,
+};
 
 /// In-memory location of the [`VbeInfoBlock`] header
 pub const VESA_VBE_BUFFER: u16 = 0x4f00;
@@ -65,7 +68,7 @@ pub struct VbeInfoBlock {
 /// Can only be used while in real mode, or through a vm86
 /// monitor.
 #[cfg(feature = "real")]
-pub fn real_set_vesa_mode(mode: u16) -> Result<(), ()> {
+pub fn real_set_vesa_mode(mode: u16) -> CanFail<VideoError> {
     use crate::rerror;
 
     let result: u16;
@@ -91,7 +94,7 @@ pub fn real_set_vesa_mode(mode: u16) -> Result<(), ()> {
 
     if result != VBE_SUCCESS {
         rerror!("Failed to set VESA mode");
-        return Err(());
+        return Err(VideoError::VesaError);
     }
 
     Ok(())


### PR DESCRIPTION
Tries to improve the way errors (either recoverable or unrecoverable) are handled throughout the boot process.

- Adds generic error types (`BaseError`) and common results aliases `CanFail` and `GenericError`. 
- Defines several common enums with frequent errors (`IOError`, ...)