### PR TITLE
feat(time): implement time-related macros for time measurement

### DIFF
--- a/src/fzboot/main/src/main.rs
+++ b/src/fzboot/main/src/main.rs
@@ -65,7 +65,7 @@ pub fn clock_init() {
     hpet_clk_init();
     TSCClock::init();
 
-    let curr_time = time::now();
+    let curr_time = time::date();
 
     info!("rtc_clock", "Standard UTC time {curr_time}");
     info!(


### PR DESCRIPTION
Implement several macros useful for time management:

- `wait`: waits for a given a mount of time
- `wait_for` / `wait_for_or`: waits until a condition is met or a timeout is reached
- `while_timeout`: classic while loop with an added timeout